### PR TITLE
chore: fixed wrong input argument mapping & added additional arguments support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,16 @@ provide a value for an argument, the default value will be used. But for those
 arguments that don't have a default value are optional and are not used unless
 you provide a value for them.
 
-| Argument           | Description                   | Default | Value                                            |
-| ------------------ | ----------------------------- | ------- | ------------------------------------------------ |
-| surrealdb_version  | SurrealDB version to use      | latest  | `latest`, `v1.x.x`                               |
-| surrealdb_port     | Port to run SurrealDB on      | 8000    | Valid number from `0` to `65535`                 |
-| surrealdb_username | Username to use for SurrealDB |         | Customisable by the user                         |
-| surrealdb_password | Password to use for SurrealDB |         | Customisable by the user                         |
-| surrealdb_auth     | Enable authentication         |         | `true`, `false`                                  |
-| surrealdb_strict   | Enable strict mode            |         | `true`, `false`                                  |
-| surrealdb_log      | Enable logs                   |         | `none`, `full`, `warn`, `info`, `debug`, `trace` |
+| Argument                  | Description                        | Default | Value                                                                                |
+| ------------------------- | ---------------------------------- | ------- | ------------------------------------------------------------------------------------ |
+| surrealdb_version         | SurrealDB version to use           | latest  | `latest`, `v1.x.x`                                                                   |
+| surrealdb_port            | Port to run SurrealDB on           | 8000    | Valid number from `0` to `65535`                                                     |
+| surrealdb_username        | Username to use for SurrealDB      |         | Customisable by the user                                                             |
+| surrealdb_password        | Password to use for SurrealDB      |         | Customisable by the user                                                             |
+| surrealdb_auth            | Enable authentication              |         | `true`, `false`                                                                      |
+| surrealdb_strict          | Enable strict mode                 |         | `true`, `false`                                                                      |
+| surrealdb_log             | Enable logs                        |         | `none`, `full`, `warn`, `info`, `debug`, `trace`                                     |
+| surrealdb_additional_args | Additional arguments for SurrealDB |         | [Any valid SurrealDB CLI arguments](https://surrealdb.com/docs/surrealdb/cli/start#) |
 
 ## Usage
 
@@ -43,6 +44,7 @@ jobs:
         surrealdb_auth: false
         surrealdb_strict: false
         surrealdb_log: info
+		surrealdb_additional_args: --allow-all
 ```
 
 ## License

--- a/action.yml
+++ b/action.yml
@@ -36,10 +36,10 @@ runs:
  using: "docker"
  image: "DockerFile"
  args:
- - ${{ inputs.surrealdb-version }}
- - ${{ inputs.surrealdb-port }}
- - ${{ inputs.surrealdb-username }}
- - ${{ inputs.surrealdb-password }}
- - ${{ inputs.surrealdb-auth }}
- - ${{ inputs.surrealdb-strict }}
- - ${{ inputs.surrealdb-log }}
+ - ${{ inputs.surrealdb_version }}
+ - ${{ inputs.surrealdb_port }}
+ - ${{ inputs.surrealdb_username }}
+ - ${{ inputs.surrealdb_password }}
+ - ${{ inputs.surrealdb_auth }}
+ - ${{ inputs.surrealdb_strict }}
+ - ${{ inputs.surrealdb_log }}

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,9 @@ inputs:
   surrealdb_log:
     description: "Enable logs printed out in the console."
     required: false
+  surrealdb_additional_args:
+    description: "Additional arguments to pass to SurrealDB"
+    required: false
   
 runs:
  using: "docker"
@@ -43,3 +46,4 @@ runs:
  - ${{ inputs.surrealdb_auth }}
  - ${{ inputs.surrealdb_strict }}
  - ${{ inputs.surrealdb_log }}
+ - ${{ inputs.surrealdb_additional_args }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,6 +7,7 @@ PASSWORD=$4 		# Password to access for root user, default is not provided
 AUTH=$5 			# Enable or disable authentication, default is not provided
 STRICT=$6 			# Enable or disable strict mode, default is not provided
 LOG=$7 				# Setting logging, default is not provided. SurrealDB sets logging to `info` by default
+ADDITIONAL=$8 		# Additional arguments to pass to the SurrealDB service
 
 if [ -z "$VERSION" ]; then
 	VERSION="latest"
@@ -46,7 +47,11 @@ else
 	LOG="--log $LOG"
 fi
 
+if [ -z "$ADDITIONAL" ]; then
+	ADDITIONAL=""
+fi
+
 echo "SurrealDB version: $VERSION - Port: $PORT"
 
 docker pull surrealdb/surrealdb:$VERSION
-docker run --name surrealdb --publish $PORT:8000 --detach surrealdb/surrealdb:$VERSION start $USERNAME $PASSWORD $AUTH $STRICT $LOG
+docker run --name surrealdb --publish $PORT:8000 --detach surrealdb/surrealdb:$VERSION start $USERNAME $PASSWORD $AUTH $STRICT $LOG $ADDITIONAL


### PR DESCRIPTION
- args were not being used by wrong input argument mapping in the github action file.
- add additional arguments that should cover every single CLI arguments that SurrealDB provides.