### PR TITLE
Update git checkout action

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Git checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Start SurrealDB
       uses: surrealdb/setup-surreal@v2
       with:


### PR DESCRIPTION
Just a minor docs update, we should probably be recommending the current version of [`actions/checkout`](https://github.com/actions/checkout).